### PR TITLE
Fix snipsync doesn't work with intellij

### DIFF
--- a/snipsync/environment.py
+++ b/snipsync/environment.py
@@ -80,7 +80,7 @@ ALLOWED_TOKENS = [
 class IdeEnum(Enum):
     PYCHARM = "PyCharm"
     WEBSTORM = "WebStorm"
-    IDEAI = "IdeaI"
+    IDEA = "Idea"
     GOLAND = "GoLand"
 
 


### PR DESCRIPTION
OS info
- mac os(intel) big sur

English is not my native language. please excuse typing errors.

First, really thank you for making awesome program.
when I use `snipsync auto-sync` command abort with below error.
```error log
Given path ~/Library/Application Support/JetBrains/IntelliJIdea2021.3/templates invalid. Must contain one of: ['PyCharm', 'WebStorm', 'IdeaI', 'GoLand']
```

because my intellij path only include Idea not IdeaI.
so I changed IDEAI = "IdeaI" enum to Idea = "Idea" and work fine.